### PR TITLE
replace deprecated cuda calls in cuda_memtest

### DIFF
--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -143,7 +143,7 @@ thread_func(void* _arg)
 
 
     cudaSetDevice(device);
-    cudaThreadSynchronize();
+    cudaDeviceSynchronize();
     CUERR;
 
     PRINTF("Attached to device %d successfully.\n", device);

--- a/cuda_memtest.h
+++ b/cuda_memtest.h
@@ -113,7 +113,7 @@ extern void get_driver_info(char* info, unsigned int len);
 
 
 #define SHOW_PROGRESS(msg, i, tot_num_blocks)				\
-    cudaThreadSynchronize();						\
+    cudaDeviceSynchronize();						\
     unsigned int num_checked_blocks =  i+GRIDSIZE <= tot_num_blocks? i+GRIDSIZE: tot_num_blocks; \
     if (verbose >=2){							\
 	if(interactive){ \
@@ -132,7 +132,7 @@ extern void get_driver_info(char* info, unsigned int len);
 	    exit(cuda_err);}}while(0)
 
 #define SYNC_CUERR  do{ cudaError_t cuda_err; \
-	cudaThreadSynchronize(); \
+	cudaDeviceSynchronize(); \
         if ((cuda_err = cudaGetLastError()) != cudaSuccess) {                \
             FPRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \
             PRINTF("ERROR: CUDA error: %s, line %d, file %s\n", cudaGetErrorString(cuda_err),  __LINE__, __FILE__); \

--- a/tests.cu
+++ b/tests.cu
@@ -191,7 +191,7 @@ error_checking(const char* msg, unsigned int blockidx)
 	cudaMemset((void*)&err_expect[0], 0, sizeof(unsigned long)*MAX_ERR_RECORD_COUNT);CUERR;
 	cudaMemset((void*)&err_current[0], 0, sizeof(unsigned long)*MAX_ERR_RECORD_COUNT);CUERR;
 	if (exit_on_error){
-	    cudaThreadExit();
+	    cudaDeviceReset();
 	    exit(ERR_BAD_STATE);
 	}
     }


### PR DESCRIPTION
`cudaThread*` calls are deprecated since cuda4.0
- replace `cudaThreadSynchronize()` with `cudaDeviceSynchronize()`
- replace `cudaThreadExit()` with `cudaDeviceReset()`
