### PR TITLE
Code Cleanup & PThreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,12 @@ endif()
 ################################################################################
 
 find_package(Threads REQUIRED)
+list(APPEND LIBS ${CMAKE_THREAD_LIBS_INIT})
+
+# work around for Hypnos (Ubuntu 14.04) with gcc 4.8.2
+if(NOT CMAKE_THREAD_LIBS_INIT)
+    list(APPEND LIBS "-pthread")
+endif()
 
 
 ################################################################################
@@ -79,27 +85,21 @@ find_package(Threads REQUIRED)
 ################################################################################
 
 option(CUDA_MEMTEST_RELEASE "disable all runtime asserts" ON)
-if(PIC_RELEASE)
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=-pthread")
+if(CUDA_MEMTEST_RELEASE)
     add_definitions(-DNDEBUG)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" "-Xcompiler=-pthread")
-else(PIC_RELEASE)
+else(CUDA_MEMTEST_RELEASE)
     set(CMAKE_BUILD_TYPE Debug)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -g "-Xcompiler=-g,-pthread")
-endif(PIC_RELEASE)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=-g")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -g")
+endif(CUDA_MEMTEST_RELEASE)
 
 
 ################################################################################
 # Warnings
 ################################################################################
 
-set(CMAKE_CXX_FLAGS_DEFAULT "-Wall")
-
-
-################################################################################
-# Configure include directories
-################################################################################
-
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} ${INCLUDE_DIRECTORIES})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 
 ################################################################################
@@ -112,7 +112,7 @@ cuda_add_executable(cuda_memtest
     cuda_memtest.cu
 )
 
-target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY})
 
 
 ################################################################################
@@ -120,4 +120,4 @@ target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY} ${CMAKE_THREAD
 ################################################################################
 
 install(TARGETS cuda_memtest
-         RUNTIME DESTINATION bin)
+        RUNTIME DESTINATION bin)

--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -187,7 +187,7 @@ thread_func(void* _arg)
 
 
 void*
-temp_monitor_thread_func(void* arg)
+temp_monitor_thread_func(void*)
 {
     do{
         update_temperature();

--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -76,6 +76,7 @@ pthread_mutex_t atomic_mutex = PTHREAD_MUTEX_INITIALIZER;
 void run_tests(char*, unsigned int);
 extern void update_temperature(void);
 extern void allocate_small_mem(void);
+volatile int active_update_temperature;
 
 typedef struct arg_s{
     unsigned int device;
@@ -189,16 +190,16 @@ void*
 temp_monitor_thread_func(void* arg)
 {
     do{
-	update_temperature();
-	sleep(monitor_interval);
-    }while(1);
-
+        update_temperature();
+        sleep(monitor_interval);
+    }while(active_update_temperature);
+    return NULL;
 }
 
 
 void list_tests_info(void)
 {
-    int i;
+    size_t i;
     for (i = 0;i < DIM(cuda_memtests); i++){
 	printf("%s %s\n", cuda_memtests[i].desc, cuda_memtests[i].enabled?"":" ==disabled by default==");
     }
@@ -319,7 +320,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    int idx = atoi(argv[i+1]);
+	    size_t idx = atoi(argv[i+1]);
 	    if (idx >= DIM(cuda_memtests)){
 		fprintf(stderr, "Error: invalid test id\n");
 		usage(argv);
@@ -334,7 +335,7 @@ main(int argc, char** argv)
 	    if (i+1 >= argc){
 		usage(argv);
 	    }
-	    int idx = atoi(argv[i+1]);
+	    size_t idx = atoi(argv[i+1]);
 	    if (idx >= DIM(cuda_memtests)){
 		fprintf(stderr, "Error: invalid test id\n");
 		usage(argv);
@@ -345,7 +346,7 @@ main(int argc, char** argv)
 	    continue;
 	}
 	if (strcmp(argv[i], "--disable_all") == 0){
-	    int k;
+	    size_t k;
 	    for (k=0;k < DIM(cuda_memtests);k++){
 		cuda_memtests[k].enabled = 0;
 	    }
@@ -475,7 +476,7 @@ main(int argc, char** argv)
 
 	if (strcmp(argv[i], "--stress") == 0){
 	    //equal to "--disable_all --enable_test 10 --exit_on_error"
-	    int k;
+	    size_t k;
 	    for (k=0;k < DIM(cuda_memtests);k++){
 		cuda_memtests[k].enabled = 0;
 	    }
@@ -500,6 +501,7 @@ main(int argc, char** argv)
     }
     pthread_t temp_pid;
     if (monitor_temp){
+	active_update_temperature = 1;
 	if (pthread_create(&temp_pid, NULL, temp_monitor_thread_func, NULL)  != 0){
 	    printf("ERROR: creating thread for temperature monitoring failed\n");
 	    exit(ERR_GENERAL);
@@ -552,6 +554,7 @@ main(int argc, char** argv)
 	exit(ERR_BAD_STATE);
     }
 
+    active_update_temperature = 0;
 
     for(i=0;i < num_gpus;i++){
 	pthread_join(pid[i], NULL);

--- a/tests.cu
+++ b/tests.cu
@@ -588,7 +588,7 @@ test0(char* ptr, unsigned int tot_num_blocks)
     kernel_test0_global_read<<<1, 1>>>(ptr, end_ptr, err_count, err_addr, err_expect, err_current, err_second_read); SYNC_CUERR;
     error_checking("test0 on global address",  0);
 
-    for(int ite = 0;ite < num_iterations; ite++){
+    for(unsigned int ite = 0;ite < num_iterations; ite++){
 	for (i=0;i < tot_num_blocks; i+= GRIDSIZE){
 	    dim3 grid;
 	    grid.x= GRIDSIZE;


### PR DESCRIPTION
CMake: Add Correct Warning and Fix missing -pthread. `-pthread` was missing in `make VERBOSE=1` and caused undefined symbols on Hypnos with gcc 4.8.2 .

Fix (un)singed compares and return types: Warnings seen with `-Wall` on gcc 4.8.2 .
