### PR TITLE
Fix Broken __MEMTEST_H__ Header Guard

### DIFF
--- a/cuda_memtest.h
+++ b/cuda_memtest.h
@@ -39,7 +39,7 @@
  */
 
 #ifndef __MEMTEST_H__
-#define __MEMTEST_H_
+#define __MEMTEST_H__
 
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
Define was never active.
Found with clang while adding travis-ci.org support for CI.
