### PR TITLE
Includes: C includes in C++

### DIFF
--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -40,12 +40,12 @@
 
 #include "misc.h"
 #include <pthread.h>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <signal.h>
+#include <csignal>
 
 #define MAX_NUM_GPUS 8
 bool useMappedMemory;

--- a/cuda_memtest.h
+++ b/cuda_memtest.h
@@ -41,7 +41,7 @@
 #ifndef __MEMTEST_H__
 #define __MEMTEST_H__
 
-#include <stdio.h>
+#include <cstdio>
 #include <stdint.h>
 #include <pthread.h>
 #include <iostream>

--- a/misc.h
+++ b/misc.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 #include "cuda_memtest.h"
 
 void update_temperature(void);

--- a/ocl_memtest.cpp
+++ b/ocl_memtest.cpp
@@ -3,10 +3,10 @@
 #include <CL/cl_gl.h>
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <sys/time.h>
-#include <string.h>
+#include <cstring>
 #include <pthread.h>
 #include <unistd.h>
 

--- a/ocl_tests.cpp
+++ b/ocl_tests.cpp
@@ -3,10 +3,10 @@
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
 #include <sys/time.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <unistd.h>
 #include <pthread.h>
 

--- a/tests.cu
+++ b/tests.cu
@@ -38,7 +38,7 @@
  * DEALINGS WITH THE SOFTWARE.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "misc.h"
 #include <cuda.h>
 #include <sys/time.h>


### PR DESCRIPTION
Transform all C includes to correct C++98 `<c...>` includes.

@psychocoderHPC @erikzenker 
