### PR TITLE
Travis: Migrate to Trusty Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,29 @@
 language: cpp
 
+sudo: required
+dist: trusty
+
 compiler:
   - gcc
   - clang
+
+matrix:
+  allow_failures:
+    - compiler: clang
+
+addons:
+  apt:
+    #sources:
+    #  - multiverse
+    packages:
+      - build-essential
+      - cmake-data
+      - cmake
+      - g++-4.8
+      - gcc-4.8
+      - nvidia-common
+    #  - nvidia-cuda-toolkit
+    #  - nvidia-cuda-dev
 
 env:
   global:
@@ -10,25 +31,25 @@ env:
     - NVML_FILE=cuda_346.46_gdk_linux.run
     - NVML_LINK=http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/
   matrix:
-    - USE_NVML=1
-    - USE_NVML=0
+    - USE_NVML=1 USE_SM=sm_10
+    - USE_NVML=0 USE_SM=sm_20
 
 script:
   - mkdir build_tmp && cd build_tmp
-# CUDA 4.0 on travis... work-around missing atomicAdd
-  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCUDA_ARCH=sm_10 -DSAME_NVCC_FLAGS_IN_SUBPROJECTS=ON $TRAVIS_BUILD_DIR
+  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCUDA_ARCH=$USE_SM -DSAME_NVCC_FLAGS_IN_SUBPROJECTS=ON $TRAVIS_BUILD_DIR
   - make
   - make install
 
-before_script:
+before_install:
+  - sudo apt-add-repository multiverse
   - sudo apt-get update -qq
-  - sudo apt-get install -qq build-essential
-  - sudo apt-get install -qq gcc-4.4 g++-4.4
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4
+  # nvcc 5.5: <= gcc 4.8
+#  - sudo apt-get install -qq gcc-4.8 g++-4.8
+#  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
   - gcc --version && g++ --version
-  - sudo apt-get install -qq nvidia-common
-  - sudo apt-get install -qq nvidia-current
-  - sudo apt-get install -qq nvidia-cuda-toolkit nvidia-cuda-dev
+  - sudo apt-get install -qq nvidia-cuda-toolkit
+  - sudo apt-get install -qq nvidia-cuda-dev
+  - nvcc --version
   - if [ $USE_NVML -eq 1 ]; then wget $NVML_LINK$NVML_FILE && chmod u+x $NVML_FILE && sudo ./$NVML_FILE --silent --installdir=/ ; fi
   - if [ $USE_NVML -eq 1 ]; then export CMAKE_PREFIX_PATH=/usr/src/gdk/nvml/lib/ ; fi
   - sudo find /usr/ -name libcuda*.so


### PR DESCRIPTION
- migrate from precise to trusty (nvcc: 4.0 -> 5.5, gcc: 4.4->4.8)
- install cuda from multiverse packages

@erikzenker @psychocoderHPC @PrometheusPi 
