### PR TITLE
Travis: Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
 
 env:
   global:
+    - CXXFLAGS="-Wall -Wextra -Werror"
     - INSTALL_DIR=~/mylibs
     - NVML_FILE=cuda_346.46_gdk_linux.run
     - NVML_LINK=http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/

--- a/misc.cpp
+++ b/misc.cpp
@@ -31,6 +31,9 @@ void get_serial_number(unsigned int devIdx, char* serial)
 
     unsigned int serialLength = NVML_DEVICE_SERIAL_BUFFER_SIZE;
     NVML_CHECK(nvmlDeviceGetSerial( devHandle, serial, serialLength ));
+#else
+    (void)(devIdx);
+    (void)(serial);
 #endif
 }
 


### PR DESCRIPTION
- in CI, warnings are errors
- add `-Wall -Wextra`
- fix an unused parameter warning if NVML is not found