### PR TITLE
Remove cuBLAS Include

### DIFF
--- a/cuda_memtest.h
+++ b/cuda_memtest.h
@@ -48,7 +48,6 @@
 #include <stdexcept>
 
 #include <cuda.h>
-#include <cublas.h>
 #if (ENABLE_NVML==1)
 #include <nvml.h>
 #endif


### PR DESCRIPTION
The cuBLAS include is not used and just pulls in a unnecessary dependency. Spotted during the review of https://github.com/ComputationalRadiationPhysics/picongpu/pull/2286