### PR TITLE
CMake: Honor _ROOT Env Hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 2.8.5)
 
 
 ################################################################################
-# Project 
+# Project
 ################################################################################
 
 project(CUDA_memtest)
@@ -23,7 +23,19 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 
 
 ################################################################################
-# Find CUDA 
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+################################################################################
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
+################################################################################
+# Find CUDA
 ################################################################################
 
 find_package(CUDA REQUIRED)


### PR DESCRIPTION
CMake 3.12+ honor `<Package>_ROOT` environment hints which are often set on HPC systems. Previously, it was only looking for `<Package>_DIR` paths in `find_package` calls.

This new policy is useful since HPC systems usually set `_DIR`, `_ROOT` or expand the `CMAKE_PREFIX_PATH`. Therefore we want to use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also throws a warning if the default (OLD) policy is used with CMake 3.12 or newer.

### References

- https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
- https://github.com/openPMD/openPMD-api/pull/391
- https://github.com/ComputationalRadiationPhysics/picongpu/pull/2891