### PR TITLE
Fix segfaults on >8 GPU systems

### DIFF
--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -47,7 +47,7 @@
 #include <sys/time.h>
 #include <csignal>
 
-#define MAX_NUM_GPUS 8
+#define MAX_NUM_GPUS 128
 bool useMappedMemory;
 void* mappedHostPtr;
 char hostname[64];

--- a/cuda_memtest.cu
+++ b/cuda_memtest.cu
@@ -498,6 +498,7 @@ main(int argc, char** argv)
     PRINTF("num_gpus=%d\n", num_gpus);
     if(num_gpus > MAX_NUM_GPUS){
 	fprintf(stderr, "Error: max number of GPUs (%d) exceeded: %d\n", MAX_NUM_GPUS, num_gpus);
+        exit(ERR_GENERAL);
     }
     pthread_t temp_pid;
     if (monitor_temp){


### PR DESCRIPTION
If a system has more than 8 GPUs, the program segfaults on some of the tests without showing an obvious problem.

This PR adds an early exit for such a scenario to avoid random segfaults.
It also increases the limit to a more reasonable number for current systems. The impact on the memory footprint should be minimal.