### PR TITLE
CMake: fix warning CMP0023

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ cuda_add_executable(cuda_memtest
     cuda_memtest.cu
 )
 
-target_link_libraries(cuda_memtest ${LIBS} ${CUDA_CUDART_LIBRARY})
+target_link_libraries(cuda_memtest PRIVATE ${LIBS} ${CUDA_CUDART_LIBRARY})
 
 
 ################################################################################


### PR DESCRIPTION
fix warning

```
Policy CMP0023 is not set: Plain and keyword target_link_libraries
  signatures cannot be mixed.  Run "cmake --help-policy CMP0023" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  The keyword signature for target_link_libraries has already been used with
  the target "cuda_memtest".  All uses of target_link_libraries with a target
  should be either all-keyword or all-plain.

  The uses of the keyword signature are here:
```