### PR TITLE
fix warning `unused return value`

### DIFF
--- a/cuda_memtest.cpp
+++ b/cuda_memtest.cpp
@@ -153,18 +153,18 @@ thread_func(void* _arg)
     }
 
     unsigned int tot_num_blocks_old = tot_num_blocks;
-    apiError_t err;
 
     // Try to allocate tot_num_blocks memory, if this fails we reduce the number of blocks
     // until we find a valid number of blocks which can be allocated.
     do{
         // reset error
-        MEMTEST_API_PREFIX(GetLastError());
+        CUERR(MEMTEST_API_PREFIX(GetLastError()));
         DEBUG_PRINTF("Trying to allocate %d MB\n", tot_num_blocks);
         if (tot_num_blocks <= 0){
             FPRINTF("ERROR: cannot allocate any memory from GPU\n");
             exit(ERR_GENERAL);
         }
+        apiError_t err;
         if(useMappedMemory)
         {
             //create cuda mapped memory


### PR DESCRIPTION
```
cuda_memtest/cuda_memtest.cpp:162:9: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
        MEMTEST_API_PREFIX(GetLastError());
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rwidera/workspace/picongpu/thirdParty/cuda_memtest/cuda_memtest.h:62:38: note: expanded from macro 'MEMTEST_API_PREFIX'
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rwidera/workspace/picongpu/thirdParty/cuda_memtest/cuda_memtest.h:41:36: note: expanded from macro 'MEMTEST_PP_CONCAT_DO'
                                   ^~~~
<scratch space>:140:1: note: expanded from here
hipGetLastError
^~~~~~~~~~~~~~~
```