### PR TITLE
CI: fix "no enabled runners online to process the request"

### DIFF
--- a/.github/workflows/dependencies/nvcc11.sh
+++ b/.github/workflows/dependencies/nvcc11.sh
@@ -13,18 +13,16 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
-sudo apt-key add 7fa2af80.pub
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
-    | sudo tee /etc/apt/sources.list.d/cuda.list
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-0 \
-    cuda-compiler-11-0           \
-    cuda-cupti-dev-11-0          \
-    cuda-minimal-build-11-0      \
-    cuda-nvml-dev-11-0
+    cuda-command-line-tools-11-7 \
+    cuda-compiler-11-7           \
+    cuda-cupti-dev-11-7          \
+    cuda-minimal-build-11-7      \
+    cuda-nvml-dev-11-7
 sudo ln -s cuda-11.0 /usr/local/cuda
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,13 +9,14 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_gcc_nvcc:
     name: NVCC 11.0.2 SP [Linux]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Install dependencies
       run: |
         .github/workflows/dependencies/nvcc11.sh
-    - name: build
+    - name: Build
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
The last four runs of the CI failed with the error:
```
This request was automatically failed because there were no runners enabled online to process the request for more than 1 day.
```
This PR fixes the problem.