### PR TITLE
Fixes

### DIFF
--- a/cuda_memtest.cpp
+++ b/cuda_memtest.cpp
@@ -575,11 +575,11 @@ main(int argc, char** argv)
 	exit(ERR_BAD_STATE);
     }
 
-    active_update_temperature = 0;
-
     for(i=0;i < num_gpus;i++){
 	pthread_join(pid[i], NULL);
     }
+
+    active_update_temperature = 0;
 
     printf("main thread: Program exits\n");
 

--- a/misc.cpp
+++ b/misc.cpp
@@ -8,13 +8,24 @@ void update_temperature(void)
     unsigned int deviceCount;
     NVML_CHECK(nvmlDeviceGetCount( &deviceCount ));
 
-    for( unsigned int devIdx = 0; devIdx < deviceCount; ++devIdx )
+    unsigned int monitoredCount = (deviceCount > MAX_GPU_NUM) ? MAX_GPU_NUM : deviceCount;
+    if (deviceCount > MAX_GPU_NUM) {
+        fprintf(stderr, "WARNING: Found %u GPUs, but MAX_GPU_NUM is %u. Clamping to maximum supported.\n", deviceCount, MAX_GPU_NUM);
+    }
+
+    for( unsigned int devIdx = 0; devIdx < monitoredCount; ++devIdx )
     {
         nvmlDevice_t devHandle;
         NVML_CHECK(nvmlDeviceGetHandleByIndex( devIdx, &devHandle ));
 
         unsigned int devTemperature;
+#if (NVML_API_VERSION >= 13)
+        nvmlTemperature_t temperature = {nvmlTemperature_v1, NVML_TEMPERATURE_GPU};
+        NVML_CHECK(nvmlDeviceGetTemperatureV( devHandle, &temperature ));
+        devTemperature = temperature.temperature;
+#else
         NVML_CHECK(nvmlDeviceGetTemperature( devHandle, NVML_TEMPERATURE_GPU, &devTemperature ));
+#endif
         gpu_temp[devIdx] = devTemperature;
 
         DEBUG_PRINTF("temperature updated: (gpu %d) %d \n", devIdx, devTemperature);


### PR DESCRIPTION
Updates get temperature for newer NVML API versions. Closes #54
Fix bug which causes the temperature measurement thread to exit too early. Closes #56
Add guard in case num GPUs exceeds `MAX_GPU_NUM`. Closes #55

These fixes are based on patches provided by @alyoshin 